### PR TITLE
Add option to execute fetch manually

### DIFF
--- a/src/useAxios.js
+++ b/src/useAxios.js
@@ -1,45 +1,53 @@
-import { useEffect, useReducer, useRef } from 'react'
-import axios, { CancelToken } from 'axios'
+import { useEffect, useReducer, useRef, useCallback } from "react";
+import axios, { CancelToken } from "axios";
 
-import reducer, { actions, initialState } from './reducer'
+import reducer, { actions, initialState } from "./reducer";
 
-export default function useAxios(options) {
-  if (typeof options === 'string') {
+/**
+ * useAxios
+ * @param {string | options} options
+ * @param {boolean} manual - True: to execute the fetch onMount
+ * @example
+ * const [state, execute, cancel] = useAxios("/api", false);
+ */
+export default function useAxios(options, manual = true) {
+  if (typeof options === "string") {
     // eslint-disable-next-line no-param-reassign
     options = {
       url: options,
-      method: 'GET'
-    }
+      method: "GET"
+    };
   }
 
-  const [state, dispatch] = useReducer(reducer, initialState)
+  const [state, dispatch] = useReducer(reducer, initialState);
 
-  const cancel = useRef()
-  useEffect(() => {
-    (async () => {
-      dispatch({ type: actions.REQUEST_START })
-      try {
-        const response = await axios({
-          ...options,
-          ...{
-            cancelToken: new CancelToken(c => {
-              cancel.current = c
-            })
-          }
-        })
-        dispatch({ type: actions.REQUEST_SUCCESS, payload: response })
-      } catch (e) {
-        if (axios.isCancel(e)) {
-          dispatch({ type: actions.REQUEST_CANCEL })
-          return
+  const cancel = useRef();
+
+  const fetch = useCallback(async () => {
+    dispatch({ type: actions.REQUEST_START });
+    try {
+      const response = await axios({
+        ...options,
+        ...{
+          cancelToken: new CancelToken(c => {
+            cancel.current = c;
+          })
         }
-        dispatch({ type: actions.REQUEST_FAIL, payload: e })
+      });
+      dispatch({ type: actions.REQUEST_SUCCESS, payload: response });
+    } catch (e) {
+      if (axios.isCancel(e)) {
+        dispatch({ type: actions.REQUEST_CANCEL });
+        return;
       }
-    })()
+      dispatch({ type: actions.REQUEST_FAIL, payload: e });
+    }
+  }, [options]);
 
-    return () => cancel.current('useAxios cancelled on component un-mount')
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(options)])
+  useEffect(() => {
+    manual && fetch();
+    return () => cancel.current("useAxios cancelled on component un-mount");
+  }, [fetch, manual]);
 
-  return [state, cancel.current]
+  return [state, fetch, cancel.current];
 }


### PR DESCRIPTION
Your library is quite nice and simple. It would be nicer to have an option to manually execute some queries (POST, PUT, DELETE, etc) onClick.